### PR TITLE
(WIP) Adding docker and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:3.2-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile* ./
+RUN bundle install
+
+EXPOSE 4000
+
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch"]

--- a/README.md
+++ b/README.md
@@ -4,25 +4,44 @@ This is the source content, database, and other internal files used for building
 
 This is a `git` repository hosted on Github at https://github.com/gutenbergtools/gutenbergsite.
 
-
 ## Development
 
-If you wish to experiment you can develop and run the site on your local machine.
+If you wish to experiment you can develop and run the site on your local machine. You can do this by installing tooling directly onto your host machine, or by running the site Docker container.
 
-Dependencies:
+### With Docker
 
-* [Ruby](https://www.ruby-lang.org/) language
-* [Jekyll](https://jekyllrb.com/) static website generator
-* Git
+#### Dependencies
 
-Once Ruby, Jekyll, and Git are setup:
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/)
 
-    git clone https://github.com/gutenbergtools/gutenbergsite.git
-    cd gutenbergsite
-    bundle exec jekyll serve
+With Docker install simply run
+
+```sh
+git clone https://github.com/gutenbergtools/gutenbergsite.git
+cd gutenbergsite
+docker compose up
+```
 
 Then open your web browser to http://localhost:4000
 
+### Without Docker 
+
+#### Dependencies
+
+* [Ruby](https://www.ruby-lang.org/) language
+* [Jekyll](https://jekyllrb.com/) static website generator
+* [Git](https://git-scm.com/)
+
+Once Ruby, Jekyll, and Git are setup:
+
+```sh
+git clone https://github.com/gutenbergtools/gutenbergsite.git
+cd gutenbergsite
+bundle exec jekyll serve
+```
+
+Then open your web browser to http://localhost:4000
 
 ### Further Information
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+
+services:
+  jekyll:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "4000:4000"
+    environment:
+      - JEKYLL_ENV=development


### PR DESCRIPTION
This PR adds support for running the Project Gutenberg site in a Linux container using Docker and docker-compose (or any alternative OCI compliant tooling, ie podman) to make it easier to start working on the site. 

Running the site is now as simple as 

```bash
$ docker compose up --build
```

Then open http://localhost:4000 to see the site!

## Motivation

I am not a Ruby native and do not have Ruby, Bundler or Jekyll installed on my local machine. To start working on Project Gutenberg I need to install tools directly onto my host machine and may end up using a different version of Ruby, Bundler, libssl (OpenSSL), libxml, etc. All of these difference could result in different behavior when I try to build the site.   

The solution to this is to support running the site in a Linux container and version controlling the Linux container build config as a Dockerfile. This allows us to describe the environment used to build the site in source control and gives us stronger guarantees of reproducible builds.  

I also think that Docker is much more common than Ruby, and it is more likely someone looking to contribute to Project Gutenberg will have Docker installed than Ruby. 

In the 2024 Stack Overflow Developer Survery only [5.2% of respondents reported doing extensive work in Ruby](https://survey.stackoverflow.co/2024/technology/#1-programming-scripting-and-markup-languages) over the past year, while [53.9% of respondents reported using Docker for extensive development work in the past year](https://survey.stackoverflow.co/2024/technology/#1-other-tools). In fact Docker was the most popular tooling listed.

