### PR TITLE
switch to new bsky handle

### DIFF
--- a/site/ebooks/offline_catalogs.md
+++ b/site/ebooks/offline_catalogs.md
@@ -65,7 +65,7 @@ The "[posted](https://lists.pglaf.org/mailman3/lists/?count=50&page=1)" list is 
     <li><a href="https://mastodon.social/@gutenberg_org" rel="me">
       <img src="/gutenberg/m_icon.png" alt="Mastodon Icon" />
     </a></li>
-    <li><a href="https://bsky.app/profile/gutenbergorg.bsky.social" rel="me">
+    <li><a href="https://bsky.app/profile/gutenberg.org" rel="me">
       <img src="/gutenberg/b_icon.png" alt="Bluesky icon" />
     </a></li>
     <li>News feeds of new eBooks</li>

--- a/site/index.md
+++ b/site/index.md
@@ -84,7 +84,7 @@ Audio books are a great way to enjoy and share literature. Project Gutenberg no 
     <li><a href="https://mastodon.social/@gutenberg_org" rel="me">
       <img src="/gutenberg/m_icon.png" alt="Mastodon icon" />
     </a></li>
-    <li><a href="https://bsky.app/profile/gutenbergorg.bsky.social" rel="me">
+    <li><a href="https://bsky.app/profile/gutenberg.org" rel="me">
       <img src="/gutenberg/b_icon.png" alt="Bluesky icon" />
     </a></li>
     <li>News feeds of new eBooks</li>


### PR DESCRIPTION
new bluesky handle is @gutenberg.org