### PR TITLE
attempt to fix layout bug on small screens

### DIFF
--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -863,4 +863,9 @@ library .latest h1 {
     .summary-text-container {
         text-align: center;
     }
+
+	table.bibrec td {
+		word-wrap: break-word;
+		word-break: break-word;
+	}
 }


### PR DESCRIPTION
lengthy wikipedia links in the bottom table don't wrap on smaller screens and as a result distort the page layout.
See attached image.
The simple CSS in this pull request should fix that I think (it does for me locally).
If this looks ok, I suggest we put it onto the dev server to test it out.
J

![small_screen_layout_bug](https://github.com/user-attachments/assets/6e177e5d-b691-496c-a1f0-9479a47a9b22)
