### PR TITLE
Update .gitignore so that we can automate website push more easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,13 @@
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+
+# maintained by script(s) running on gutenbackend
 _includes/latestbooks-template.html
+_includes/latest_covers.html
 
 # Misc
 to_delete
 BACKUP
 .aider*
+


### PR DESCRIPTION
latest_covers.html gets updated by the jekyll build script, so it should not be under git control to avoid have a dirty repo.

@gbnewby I made a script (in ebookconverter directory) to automate pulling assets from the repo and deploying. Not sure about the stuff not in /gutenberg/ we can probably combine  push_website_assets.sh and cron-jekyll.sh but another day