### PR TITLE
Update footer.html 3 ways

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,22 +1,22 @@
   <ul>
       <li>
-        <a href="/about/" title="About Project Gutenberg">About Project Gutenberg</a>
+        <a href="/about/">About Project Gutenberg</a>
       </li>
       <li>
-        <a href="/policy/privacy_policy.html" title="Privacy Policy">Privacy policy</a>
+        <a href="/policy/privacy_policy.html">Privacy policy</a>
       </li>
       <li>
-        <a href="/policy/permission.html" title="Permissions">Permissions</a>
+        <a href="/policy/permission.html" title="Permissions, Licensing and other Common Requests">Permissions</a>
       </li>
       <li>
-        <a href="/policy/terms_of_use.html" title="Terms of Use">Terms of Use</a>
+        <a href="/policy/terms_of_use.html">Terms of Use</a>
       </li>
       <li>
-        <a href="/about/contact_information.html" title="Contact Information">Contact Us</a>
+        <a href="/about/contact_information.html" title="How to contact Project Gutenberg">Contact Us</a>
       </li>
-      <li><a href="/help/" title="Get Help">Help Pages</a></li>
+      <li><a href="/help/" title="Help, How-To, Procedures, Guidance and Information">Help</a></li>
   </ul>
 
   <a href="https://www.ibiblio.org/" title="Project Gutenberg is hosted by ibiblio">
-   <img src="/gutenberg/ibiblio-logo.png" alt="iBiblio">
+   <img src="/gutenberg/ibiblio-logo.png" alt="ibiblio" width="110" height="32">
   </a>


### PR DESCRIPTION
Titles updated to https://www.w3.org/TR/WCAG20-TECHS/H33.html - Some were removed, others were updated to match the title of the destination page.

Lowercase 'b' in ibiblio logo alt tag, matches the org's own branding and the logo content.

Height and width added to logo to improve page rendering speed.