### PR TITLE
Adjustements on the Homepage

### DIFF
--- a/_includes/latest_books_template.html
+++ b/_includes/latest_books_template.html
@@ -2,10 +2,10 @@
 <!-- Latest Books -->
 <div class="library" style="overflow-x: auto; position: relative;">
   <div class="box_shadow" style="min-width: 1260px;">
-   <div class="lib latest no-select">
+    <p><i>Our Newest Releases</i> <a href="/browse/recent/last1">click here for more</a></p>
+    <div class="lib latest no-select">
     {% include latest_covers.html %}
    </div>
-   <p><i>Some of our latest eBooks</i> <a href="/browse/recent/last1">Click Here for more latest books!</a></p>
  </div>
 </div>
 <!-- ending latest books -->

--- a/site/index.md
+++ b/site/index.md
@@ -4,31 +4,32 @@ title: Free eBooks | Project Gutenberg
 permalink: /
 ---
 
-Welcome to Project Gutenberg
+Project Gutenberg is a library of over 75,000 free eBooks
 ====================================================
-
-<h2 class="subtitle">Project Gutenberg is a library of over 75,000 free eBooks</h2>
 
 Choose among free epub and Kindle eBooks, download them or read them online. You will find the world's great literature here, with focus on older works for which U.S. copyright has expired. Thousands of volunteers digitized and diligently proofread the eBooks, for you to enjoy. 
 
 {% include latest_books_template.html %}
 
-**No fee or registration!** Everything from Project Gutenberg is gratis, libre, and completely without cost to readers. If you find Project Gutenberg useful, please consider a small donation to help Project Gutenberg digitize more books, maintain its online presence, and improve Project Gutenberg programs and offerings. Other ways to help include digitizing, proofreading and formatting, or reporting errors.
 
-**New donation option** with Give Freely. <a href="/donate/index.html#givefreely">More information...</a>.
+## Find Free eBooks
+
+- [Search Options](/ebooks/). By author, title, subject, language, type, popularity, and more.
+- [Main Categories](/ebooks/categories). The ones you'd find in any large bookstore.
+- [Reading Lists](/ebooks/bookshelf/). Hand-curated by volunteers.
+- [Frequently downloaded](/browse/scores/top): Top 100, or ranked [by popularity](/ebooks/search/?sort_order=downloads).
+- Visit [self.gutenberg.org](http://self.gutenberg.org) for free eBooks by contemporary authors.
+
+
+**No fee or registration!** Everything from Project Gutenberg is gratis, libre, and completely without cost to readers. If you find Project Gutenberg useful, please consider a small donation to help Project Gutenberg digitize more books, maintain its online presence, and improve Project Gutenberg programs and offerings. Other ways to help include digitizing, proofreading and formatting, or reporting errors.
 
 **No special apps needed!** Project Gutenberg eBooks require no special apps to read, just the regular Web browsers or eBook readers that are included with computers and mobile devices. There have been reports of sites that charge fees for custom apps, or for the same eBooks that are freely available from Project Gutenberg. Some of the apps might have worthwhile features, but none are required to enjoy Project Gutenberg eBooks. 
 
 **50 years of eBooks 1971-2021.** In 2021, Project Gutenberg celebrated the [first eBook](/ebooks/1) for reading enjoyment and unlimited free redistribution. This eBook was created on July 4, 1971 by Project Gutenberg's founder, Michael S. Hart. [Read more about this lasting innovation](/about/background/50years.html). Project Gutenberg is grateful to all volunteers who helped to reach this milestone anniversary. Project Gutenberg offers a vibrant and growing collection of the world's great literature. Read, enjoy, and share! 
 
-## Find Free eBooks
+**New donation option** with Give Freely. <a href="/donate/index.html#givefreely">More information...</a>.
 
-- [Search and browse](/ebooks/). By author, title, subject, language, type, popularity, and more.
-- [Bookshelves](/ebooks/bookshelf/) of related eBooks.
-- [Frequently downloaded](/browse/scores/top): Top 100, or ranked [by popularity](/ebooks/search/?sort_order=downloads).
-- [Offline catalogs](/ebooks/offline_catalogs.html): handy eBook listings and metadata to consult offline.
-- [Recently added](/ebooks/search/?query=&submit_search=Search&sort_order=release_date). The latest new and updated eBooks.
-- Visit [self.gutenberg.org](http://self.gutenberg.org) for free eBooks by contemporary authors.
+
 
 ## Audio books
 
@@ -74,12 +75,26 @@ Audio books are a great way to enjoy and share literature. Project Gutenberg no 
 </div>
 
 ## Social Media
-
-{% include social_media_icons.html %}
-
+<ul class="icon-list">
+    <li><a href="https://www.facebook.com/project.gutenberg">
+      <img src="/gutenberg/f_icon.png" alt="Facebook iccon" />
+    </a></li>
+    <li><a href="https://mastodon.social/@gutenberg_org" rel="me">
+      <img src="/gutenberg/m_icon.png" alt="Mastodon icon" />
+    </a></li>
+    <li><a href="https://bsky.app/profile/gutenberg.org" rel="me">
+      <img src="/gutenberg/b_icon.png" alt="Bluesky icon" />
+    </a></li>
+    <li>News feeds of new eBooks</li>
+    <li><a href="https://www.facebook.com/gutenberg.new">
+      <img src="/gutenberg/f_news_icon.png" alt="Facebook news feed icon" />
+    </a></li>
+    <li><a href="https://mastodon.social/@gutenberg_new" rel="me">
+      <img src="/gutenberg/m_news_icon.png" alt="Mastodon icon" />
+    </a></li>
+  </ul>
 
 <!-- ## Contact Info
 
 - [Contact Information](/about/contact_information.html): How to get in touch.
 - [Mailing lists](https://lists.pglaf.org/): Subscribe to the monthly newsletter. -->
-

--- a/site/index.md
+++ b/site/index.md
@@ -75,25 +75,7 @@ Audio books are a great way to enjoy and share literature. Project Gutenberg no 
 </div>
 
 ## Social Media
-<ul class="icon-list">
-    <li><a href="https://www.facebook.com/project.gutenberg">
-      <img src="/gutenberg/f_icon.png" alt="Facebook iccon" />
-    </a></li>
-    <li><a href="https://mastodon.social/@gutenberg_org" rel="me">
-      <img src="/gutenberg/m_icon.png" alt="Mastodon icon" />
-    </a></li>
-    <li><a href="https://bsky.app/profile/gutenberg.org" rel="me">
-      <img src="/gutenberg/b_icon.png" alt="Bluesky icon" />
-    </a></li>
-    <li>News feeds of new eBooks</li>
-    <li><a href="https://www.facebook.com/gutenberg.new">
-      <img src="/gutenberg/f_news_icon.png" alt="Facebook news feed icon" />
-    </a></li>
-    <li><a href="https://mastodon.social/@gutenberg_new" rel="me">
-      <img src="/gutenberg/m_news_icon.png" alt="Mastodon icon" />
-    </a></li>
-  </ul>
-
+{% include social_media_icons.html %}
 <!-- ## Contact Info
 
 - [Contact Information](/about/contact_information.html): How to get in touch.


### PR DESCRIPTION
Some selective adjustments on the Homepage:

- removed "Welcome to Project Gutenberg" as h1 since it's somewhat redundant
- set "Project Gutenberg is a library of over 75,000 free eBooks" as h1 instead. Simple and gets right to the point.
- moved "Our Newest Releases" up in the "latest_books" box. Make more sense to have it above the images than below.
- moved the "Find Free Ebooks" section up. Important because the most important thing new visitors need to understand is how they can find books. Having these links further up is helpful in that regard.
- adjusted the wording and links in that "Find Free Ebooks" section

I think in time a more substantial design "upgrade", like we've done for the "bibrec" and the "search options" page, should also be done for the homepage.  In the meantime this is a small set of very straightforward adjustments that in my opinion would make things a little better for users, especially new users