### PR TITLE
Update header position to fix issues with dynamic height

### DIFF
--- a/gutenberg/new_nav.css
+++ b/gutenberg/new_nav.css
@@ -4,18 +4,10 @@
   box-sizing: border-box;
 }
 
-body {
-  padding-top: 40px; /* Space for fixed header + 20px extra */
-}
-
 header {
   width: 100%;
   display: flex;
   flex-direction: column;
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1000;
 }
 
 .logo-container {

--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -146,14 +146,12 @@ a:active {
 @media screen and (orientation: landscape) {
   .container {
     min-height: 75vh;
-    padding: 10vh 5vw;
   }
 }
 
 @media screen and (orientation: portrait) {
   .container {
     min-height: 75vh;
-    padding: 10vh 5vw;
   }
 }
 
@@ -325,7 +323,7 @@ ul {
 }
 
 .page_content {
-  margin-top: 36px;
+  padding: 2em 4em;
   padding-bottom: 24px;
 }
 
@@ -361,7 +359,6 @@ ul {
 .page_content h1 {
   font-size: 1.875em;
   font-weight: bold;
-  margin-top: 2em;
   width: 100%;
   line-height: 1em;
   color: #aa873b;
@@ -569,7 +566,6 @@ ul.results li::before {
   }
 
   .page_content {
-    margin-top: 60px;
     height: auto;
   }
 


### PR DESCRIPTION
As I started looking at #124 I noticed that the DOM layout was not as I would expect. When the header expands, the content is covered instead of being pushed down. While we _could_ add padding-top in a media query to resolve this specific case, in my opinion it would be much better to fix the DOM layout in general so these issues never happen again.

The primary issue here is that the header has `position: fixed`. This pulls the header out of the DOM flow and allows other elements to render behind it. This means that all page content needs top margin/padding to be pushed below the header. To make this worse, if the header height changes, all of these padding values also need to be changed.

Instead, we should leave the header as a block level element. This will allow all other elements to be rendered below it. If the header changes in size, the rest of the page content will simply move up or down to accommodate. With this approach, the page content padding would never need to be updated, even if more header rows were added or some are removed. Additionally, it makes it impossible for content to be potentially hidden by the header.

From my perspective, there are no downsides to this approach. But please let me know if I am overlooking any areas that might be problematic. 

## Demo

https://github.com/user-attachments/assets/0aa54064-e34c-4b9d-96f7-b9c59befe063
