### PR TITLE
Make about menu keyboard accessible

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -72,7 +72,7 @@
 
   <label for="about-toggle" class="dropdown-overlay"></label>
   <div class="lower-header">
-    <div class="dropdown">
+    <div class="dropdown" tabindex="0">
       <label for="about-toggle" class="dropdown-button" aria-haspopup="true">About<span aria-hidden="true" class="dropdown-icon">▼</span></label>
       <div class="dropdown-content">
         <a href="/about/">About Project Gutenberg </a>

--- a/gutenberg/new_nav.css
+++ b/gutenberg/new_nav.css
@@ -140,6 +140,11 @@ header {
   cursor: default;
 }
 
+/* Display dropdown when focused with keyboard */
+.dropdown:focus-within .dropdown-content {
+  display: block;
+}
+
 #about-toggle:checked ~ .dropdown-overlay {
   display: block;
   z-index: 900;


### PR DESCRIPTION
Making the about menu navigable via keyboard.

## Demo

https://github.com/user-attachments/assets/f95e842c-a317-47ae-a447-ed8e08699aab

