### PR TITLE
Use flex to allow page content to grow

### DIFF
--- a/gutenberg/new_nav.css
+++ b/gutenberg/new_nav.css
@@ -4,10 +4,6 @@
   box-sizing: border-box;
 }
 
-body {
-  padding-top: 40px; /* Space for fixed header + 20px extra */
-}
-
 header {
   width: 100%;
   display: flex;

--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -10,10 +10,16 @@ body {
   max-width: 100vw;
   padding: 0;
   width: 100%;
-  height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 html {
+  height: 100%;
   overflow-y: scroll;
 }
 
@@ -138,10 +144,10 @@ a:active {
 
 /* =================== container =============================== */
 .container {
-  max-width: 100%;
-  min-height: 75vh;
+  width: 100%;
   position: relative;
-  margin-top: 50px;
+  flex: 1;
+  overflow: auto;
 }
 
 @media screen and (orientation: landscape) {
@@ -324,8 +330,8 @@ ul {
 }
 
 .page_content {
-  margin-top: 80px;
-  padding-bottom: 24px;
+  margin-top: 160px;
+  padding-bottom: 60px;
   padding-left: 5vw;
   padding-right: 5vw;
 
@@ -865,7 +871,7 @@ ul.results li::before {
     margin-top: 0;
   }
   .page_content {
-    margin-top: 20px;
+    margin-top: 60px;
     margin-bottom: 30px;
     padding: 0 5vw;
   }


### PR DESCRIPTION
Updating the styling to use flexbox so the page content can grow to fill the screen if it is not already large enough. 

## Screenshots 📸 

<details><summary>Desktop</summary>
<p>

### Desktop

![image](https://github.com/user-attachments/assets/272d1930-512e-4edb-a5f5-720affc69eff)
![image](https://github.com/user-attachments/assets/dfbf1612-b892-4af4-a08b-38281c314cdb)
![image](https://github.com/user-attachments/assets/160343c7-7234-49f5-af43-c796dc87ce0c)
![image](https://github.com/user-attachments/assets/711f2f5b-073c-4ef7-8b85-e3a33a0fd6c0)

</p>
</details> 

<details><summary>Mobile</summary>
<p>

### Tablet/Mobile

![image](https://github.com/user-attachments/assets/09ba638a-5416-442b-b3c4-3b098e69f838)
![image](https://github.com/user-attachments/assets/965d1e53-8ec5-40e4-bce4-46f3c03202b9)
![image](https://github.com/user-attachments/assets/6eeb2cb6-6d7b-450a-a17f-7e2d7491edd7)
![image](https://github.com/user-attachments/assets/92452815-1660-4764-b9e5-27926e233268)
![image](https://github.com/user-attachments/assets/b6291224-13ed-4b5f-a984-2cf231094d81)

</p>
</details> 


