### PR TITLE
Take out deprecated/unnecessary UX part on browse-by pages

### DIFF
--- a/catalog/admin/make-by-pages.php
+++ b/catalog/admin/make-by-pages.php
@@ -96,8 +96,9 @@ function _navbarcategories ($what, $dir) {
     
 function navbar () {
   global $dir_authors, $dir_titles, $dir_langs, $dir_loccs, $dir_categories, $dir_recent, $lang_thres;
-  $nav  = "<div>";
-  $nav .= "</div>"; 
+  $nav = "<div class=\"pgdbnavbar\">\n";
+  $nav .= _navbarrecent ("Recent", $dir_recent);
+  $nav .= "</div>\n\n";
   return $nav;
 }
     

--- a/catalog/admin/make-by-pages.php
+++ b/catalog/admin/make-by-pages.php
@@ -96,15 +96,8 @@ function _navbarcategories ($what, $dir) {
     
 function navbar () {
   global $dir_authors, $dir_titles, $dir_langs, $dir_loccs, $dir_categories, $dir_recent, $lang_thres;
-  $nav  = "<div class=\"pgdbnavbar\">\n";
-  $nav .= _navbar       ("Authors",   $dir_authors);
-  $nav .= _navbar       ("Titles",    $dir_titles);
-  $nav .= _navbarlangs  ("Languages with more than $lang_thres books", "> $lang_thres", $dir_langs);
-  $nav .= _navbarlangs  ("Languages with up to $lang_thres books", "<= $lang_thres", $dir_langs);
-  //  $nav .= _navbarloccs  ("LoC Class", $dir_loccs);
-  $nav .= _navbarcategories ("Special Categories", $dir_categories);
-  $nav .= _navbarrecent     ("Recent",     $dir_recent);
-  $nav .= "</div>\n\n"; 
+  $nav  = "<div>";
+  $nav .= "</div>"; 
   return $nav;
 }
     


### PR DESCRIPTION
Attempt to make the adjustment described in this issue: https://github.com/gutenbergtools/gutenbergsite/issues/116

Unfortunately I can't test locally whether this works or not. I have gutenbergsite running but the browse-by pages don't load.

Maybe we can put this on dev and see whether it does the trick. I don't claim to really understand those php scripts, but I suspect this has a good chance of working.