### PR TITLE
Update bookshelf card styling to prevent wrapping below image

### DIFF
--- a/gutenberg/pg-desktop-one.css
+++ b/gutenberg/pg-desktop-one.css
@@ -2610,7 +2610,6 @@ ul.results li.statusline {
 
 .cell.content {
   display: block;
-  margin-left: 50px;
   padding-left: 1em;
   color: #a01f13;
 }

--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -587,6 +587,11 @@ ul.results li::before {
   }
 }
 
+/* Bookshelf cards */
+.booklink .link {
+  display: flex!important
+}
+
 /*New Cover_image rules only applicable to test_index for latest covers from gutenberg1*/
 .library .latest a:link {
   text-decoration: none;


### PR DESCRIPTION
## Screenshots 📷 

Before 
<img width="448" height="162" alt="image" src="https://github.com/user-attachments/assets/2cbeabad-6160-47d2-9cfc-95503644934a" />
<img width="1493" height="796" alt="image" src="https://github.com/user-attachments/assets/b92780da-2ac2-44d9-895b-8412b311b5b6" />

After
<img width="458" height="174" alt="image" src="https://github.com/user-attachments/assets/e0341e7a-89fd-4267-bc52-462a83004453" />
<img width="1442" height="795" alt="image" src="https://github.com/user-attachments/assets/5ac5fdb5-de15-44c5-831f-98399aec5e53" />
