### PR TITLE
Upgrade Hompage

### DIFF
--- a/gutenberg/homepage.css
+++ b/gutenberg/homepage.css
@@ -1,0 +1,190 @@
+/* ---------- Base Styles ---------- */
+body {
+  line-height: 1.6;
+  color: #333;
+}
+  
+/* Headline & Slogan */
+#slogan { font-size: 32px; }
+#sub-slogan { font-size: 18px; }
+
+/* Utility */
+.box_shadow {
+  border: none;
+  border-radius: 10px;
+}
+
+/* Typography */
+i { font-style: normal; font-size: 1.25rem; }
+
+p i + a {
+  font-size: 0.85rem;
+  padding: 2px 12px;
+  border-radius: 4px;
+}
+
+/* Links */
+a {
+  color: #007bff;
+  text-decoration: none;
+  transition: color 0.15s ease-in-out,
+              transform 0.2s ease-in-out,
+              box-shadow 0.2s ease-in-out;
+}
+
+a:hover { color: #0056b3; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 500;
+  color: #212529;
+}
+
+/* ---------- Category Grid ---------- */
+.category-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 55px 0px 65px 0px;
+}
+
+.category-grid a {
+  flex: 0 0 280px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: linear-gradient(135deg, #fff 0%, #f8f9fa 100%);
+  border: 1px solid #e9ecef;
+  border-radius: 12px;
+  color: #495057;
+  font-weight: 500;
+  font-size: 1.1rem;
+  text-decoration: none !important;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.category-grid a:hover {
+  background: #7EBED0;
+  text-decoration: none !important;
+  transform: translateY(-4px);
+}
+
+.category-grid a:before {
+  content: attr(data-emoji);
+  font-size: 1.5rem;
+  filter: grayscale(0.3);
+  transition: all 0.3s ease;
+}
+
+.category-grid a:hover:before {
+  filter: grayscale(0);
+  transform: scale(1.1);
+}
+
+/* Category Grid – Responsive */
+@media (max-width: 768px) {
+  .category-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 15px;
+  }
+}
+
+@media (max-width: 480px) {
+  .category-grid { grid-template-columns: 1fr; }
+}
+
+/* ---------- Info Boxes ---------- */
+.info-box-container {
+  display: flex;
+  gap: 30px;
+  margin: 40px 0;
+}
+
+.info-box {
+  flex: 1;
+  background-color: #F0F0F0;
+  border-radius: 10px;
+  padding: 20px 20px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.04);
+  transition: transform 0.2s ease-in-out,
+              box-shadow 0.2s ease-in-out;
+}
+
+.info-box:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.info-box h3 {
+  color: #212529;
+  margin: 0 0 15px 0;
+  font-size: 1.35rem;
+}
+
+.info-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.info-box ul li { margin-bottom: 14px; line-height: 1.5; }
+
+.info-box .highlight-text {
+  color: #212529;
+  margin-bottom: 10px;
+  font-size: 0.95rem;
+}
+
+/* Info Boxes – Responsive */
+@media (max-width: 768px) {
+  .info-box-container { flex-direction: column; }
+  .info-box { margin-bottom: 15px; }
+}
+
+/* ---------- Latest Releases & Random Selection ---------- */
+.lib.latest {
+  display: flex;
+  gap: 28px;
+  padding: 0px 0px 50px 0px;
+}
+
+.lib.latest .cover_image {
+  flex-shrink: 0;
+  transition: transform 0.2s ease-in-out;
+}
+
+.lib.latest .cover_image:hover { transform: translateY(-4px); }
+
+.lib.latest .cover_img img {
+  width: 120px;
+  height: 180px;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: all 0.2s ease-in-out;
+}
+
+.lib.latest .cover_img img:hover {
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+}
+
+.lib.latest .cover_title { margin-top: 12px; max-width: 140px; }
+
+.lib.latest .cover_title h5 {
+  font-size: 0.85rem;
+  line-height: 1.3;
+  margin: 0;
+  color: #495057;
+  width: 120px;
+}
+
+/* ---------- 'Find more' link ---------- */
+.box_shadow p a { background-color: #C7DDE3; }
+
+.box_shadow p a:hover { filter: brightness(1.1); }

--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -226,6 +226,24 @@ ul {
   margin-left: -1em;
 }
 
+/* highlights the relevant header if a user arrives via a "main categories" link on the homepage */
+.bookshelves h2:target,
+.bookshelves h2:focus {
+  background: #fffbd2;
+  border: 1px solid #a01f13;
+  padding: 0.25em 0.5em;
+  animation: flash 1.5s ease-in-out 3;
+}
+
+@keyframes flash {
+  0%, 100% { background: #fffbd2; }
+  50%      { background: #ffe17d; }
+}
+
+.bookshelves h2 {
+  scroll-margin-top: 10rem; /* keeps heading out from under fixed header */
+}
+ 
 .page_content .bookshelves h2 {
   border-bottom: 0px none #ffffff;
 }

--- a/site/ebooks/categories.md
+++ b/site/ebooks/categories.md
@@ -10,110 +10,128 @@ These categories are the categories you may find in a large physical bookstore. 
 
 
 <div class="bookshelves">
-  <h2>Literature</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/644">Adventure</a></li>
-    <li><a href="/ebooks/bookshelf/654">American Literature</a></li>
-    <li><a href="/ebooks/bookshelf/653">British Literature</a></li>
-    <li><a href="/ebooks/bookshelf/652">French Literature</a></li>
-    <li><a href="/ebooks/bookshelf/651">German Literature</a></li>
-    <li><a href="/ebooks/bookshelf/650">Russian Literature</a></li>
-    <li><a href="/ebooks/bookshelf/649">Classics of Literature</a></li>
-    <li><a href="/ebooks/bookshelf/643">Biographies</a></li>
-    <li><a href="/ebooks/bookshelf/645">Novels</a></li>
-    <li><a href="/ebooks/bookshelf/634">Short Stories</a></li>
-    <li><a href="/ebooks/bookshelf/637">Poetry</a></li>
-    <li><a href="/ebooks/bookshelf/642">Plays/Films/Dramas</a></li>
-    <li><a href="/ebooks/bookshelf/639">Romance</a></li>
-    <li><a href="/ebooks/bookshelf/638">Science-Fiction &amp; Fantasy</a></li>
-    <li><a href="/ebooks/bookshelf/640">Crime, Thrillers &amp; Mystery</a></li>
-    <li><a href="/ebooks/bookshelf/646">Mythology, Legends &amp; Folklore</a></li>
-    <li><a href="/ebooks/bookshelf/641">Humor</a></li>
-    <li><a href="/ebooks/bookshelf/636">Children &amp; Young Adult Reading</a></li>
-    <li><a href="/ebooks/bookshelf/633">Literature - Other</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="literature" tabindex="-1">Literature</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/644">Adventure</a></li>
+      <li><a href="/ebooks/bookshelf/654">American Literature</a></li>
+      <li><a href="/ebooks/bookshelf/653">British Literature</a></li>
+      <li><a href="/ebooks/bookshelf/652">French Literature</a></li>
+      <li><a href="/ebooks/bookshelf/651">German Literature</a></li>
+      <li><a href="/ebooks/bookshelf/650">Russian Literature</a></li>
+      <li><a href="/ebooks/bookshelf/649">Classics of Literature</a></li>
+      <li><a href="/ebooks/bookshelf/643">Biographies</a></li>
+      <li><a href="/ebooks/bookshelf/645">Novels</a></li>
+      <li><a href="/ebooks/bookshelf/634">Short Stories</a></li>
+      <li><a href="/ebooks/bookshelf/637">Poetry</a></li>
+      <li><a href="/ebooks/bookshelf/642">Plays/Films/Dramas</a></li>
+      <li><a href="/ebooks/bookshelf/639">Romance</a></li>
+      <li><a href="/ebooks/bookshelf/638">Science-Fiction &amp; Fantasy</a></li>
+      <li><a href="/ebooks/bookshelf/640">Crime, Thrillers &amp; Mystery</a></li>
+      <li><a href="/ebooks/bookshelf/646">Mythology, Legends &amp; Folklore</a></li>
+      <li><a href="/ebooks/bookshelf/641">Humour</a></li>
+      <li><a href="/ebooks/bookshelf/636">Children &amp; Young Adult Reading</a></li>
+      <li><a href="/ebooks/bookshelf/633">Literature - Other</a></li>
+    </ul>
+  </div>
 
-  <h2>Science &amp; Technology</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/671">Engineering &amp; Technology</a></li>
-    <li><a href="/ebooks/bookshelf/672">Mathematics</a></li>
-    <li><a href="/ebooks/bookshelf/667">Science - Physics</a></li>
-    <li><a href="/ebooks/bookshelf/668">Science - Chemistry/Biochemistry</a></li>
-    <li><a href="/ebooks/bookshelf/669">Science - Biology</a></li>
-    <li><a href="/ebooks/bookshelf/670">Science - Earth/Agricultural/Farming</a></li>
-    <li><a href="/ebooks/bookshelf/673">Research Methods/Statistics/Information Sys</a></li>
-    <li><a href="/ebooks/bookshelf/685">Environmental Issues</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="science-technology" tabindex="-1">Science &amp; Technology</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/671">Engineering &amp; Technology</a></li>
+      <li><a href="/ebooks/bookshelf/672">Mathematics</a></li>
+      <li><a href="/ebooks/bookshelf/667">Science - Physics</a></li>
+      <li><a href="/ebooks/bookshelf/668">Science - Chemistry/Biochemistry</a></li>
+      <li><a href="/ebooks/bookshelf/669">Science - Biology</a></li>
+      <li><a href="/ebooks/bookshelf/670">Science - Earth/Agricultural/Farming</a></li>
+      <li><a href="/ebooks/bookshelf/673">Research Methods/Statistics/Information Sys</a></li>
+      <li><a href="/ebooks/bookshelf/685">Environmental Issues</a></li>
+    </ul>
+  </div>
 
-  <h2>History</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/656">History - American</a></li>
-    <li><a href="/ebooks/bookshelf/657">History - British</a></li>
-    <li><a href="/ebooks/bookshelf/658">History - European</a></li>
-    <li><a href="/ebooks/bookshelf/659">History - Ancient</a></li>
-    <li><a href="/ebooks/bookshelf/660">History - Medieval/Middle Ages</a></li>
-    <li><a href="/ebooks/bookshelf/661">History - Early Modern (c. 1450-1750)</a></li>
-    <li><a href="/ebooks/bookshelf/662">History - Modern (1750+)</a></li>
-    <li><a href="/ebooks/bookshelf/663">History - Religious</a></li>
-    <li><a href="/ebooks/bookshelf/664">History - Royalty</a></li>
-    <li><a href="/ebooks/bookshelf/665">History - Warfare</a></li>
-    <li><a href="/ebooks/bookshelf/666">History - Schools &amp; Universities</a></li>
-    <li><a href="/ebooks/bookshelf/655">History - Other</a></li>
-    <li><a href="/ebooks/bookshelf/686">Archaeology &amp; Anthropology</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="history" tabindex="-1">History</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/656">History - American</a></li>
+      <li><a href="/ebooks/bookshelf/657">History - British</a></li>
+      <li><a href="/ebooks/bookshelf/658">History - European</a></li>
+      <li><a href="/ebooks/bookshelf/659">History - Ancient</a></li>
+      <li><a href="/ebooks/bookshelf/660">History - Medieval/Middle Ages</a></li>
+      <li><a href="/ebooks/bookshelf/661">History - Early Modern (c. 1450-1750)</a></li>
+      <li><a href="/ebooks/bookshelf/662">History - Modern (1750+)</a></li>
+      <li><a href="/ebooks/bookshelf/663">History - Religious</a></li>
+      <li><a href="/ebooks/bookshelf/664">History - Royalty</a></li>
+      <li><a href="/ebooks/bookshelf/665">History - Warfare</a></li>
+      <li><a href="/ebooks/bookshelf/666">History - Schools &amp; Universities</a></li>
+      <li><a href="/ebooks/bookshelf/655">History - Other</a></li>
+      <li><a href="/ebooks/bookshelf/686">Archaeology &amp; Anthropology</a></li>
+    </ul>
+  </div>
 
-  <h2>Social Sciences &amp; Society</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/695">Business/Management</a></li>
-    <li><a href="/ebooks/bookshelf/696">Economics</a></li>
-    <li><a href="/ebooks/bookshelf/689">Law &amp; Criminology</a></li>
-    <li><a href="/ebooks/bookshelf/690">Gender &amp; Sexuality Studies</a></li>
-    <li><a href="/ebooks/bookshelf/688">Psychiatry/Psychology</a></li>
-    <li><a href="/ebooks/bookshelf/693">Sociology</a></li>
-    <li><a href="/ebooks/bookshelf/694">Politics</a></li>
-    <li><a href="/ebooks/bookshelf/701">Parenthood &amp; Family Relations</a></li>
-    <li><a href="/ebooks/bookshelf/700">Old Age &amp; the Elderly</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="social-sciences-society" tabindex="-1">Social Sciences &amp; Society</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/695">Business/Management</a></li>
+      <li><a href="/ebooks/bookshelf/696">Economics</a></li>
+      <li><a href="/ebooks/bookshelf/689">Law &amp; Criminology</a></li>
+      <li><a href="/ebooks/bookshelf/690">Gender &amp; Sexuality Studies</a></li>
+      <li><a href="/ebooks/bookshelf/688">Psychiatry/Psychology</a></li>
+      <li><a href="/ebooks/bookshelf/693">Sociology</a></li>
+      <li><a href="/ebooks/bookshelf/694">Politics</a></li>
+      <li><a href="/ebooks/bookshelf/701">Parenthood &amp; Family Relations</a></li>
+      <li><a href="/ebooks/bookshelf/700">Old Age &amp; the Elderly</a></li>
+    </ul>
+  </div>
 
-  <h2>Arts &amp; Culture</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/675">Art</a></li>
-    <li><a href="/ebooks/bookshelf/674">Architecture</a></li>
-    <li><a href="/ebooks/bookshelf/677">Music</a></li>
-    <li><a href="/ebooks/bookshelf/676">Fashion</a></li>
-    <li><a href="/ebooks/bookshelf/698">Journalism/Media/Writing</a></li>
-    <li><a href="/ebooks/bookshelf/687">Language &amp; Communication</a></li>
-    <li><a href="/ebooks/bookshelf/647">Essays, Letters &amp; Speeches</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="arts-culture" tabindex="-1">Arts &amp; Culture</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/675">Art</a></li>
+      <li><a href="/ebooks/bookshelf/674">Architecture</a></li>
+      <li><a href="/ebooks/bookshelf/677">Music</a></li>
+      <li><a href="/ebooks/bookshelf/676">Fashion</a></li>
+      <li><a href="/ebooks/bookshelf/698">Journalism/Media/Writing</a></li>
+      <li><a href="/ebooks/bookshelf/687">Language &amp; Communication</a></li>
+      <li><a href="/ebooks/bookshelf/647">Essays, Letters &amp; Speeches</a></li>
+    </ul>
+  </div>
 
-  <h2>Religion &amp; Philosophy</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/692">Religion/Spirituality</a></li>
-    <li><a href="/ebooks/bookshelf/691">Philosophy &amp; Ethics</a></li>
-  </ul>
-  
-  <h2>Lifestyle &amp; Hobbies</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/678">Cooking &amp; Drinking</a></li>
-    <li><a href="/ebooks/bookshelf/680">Sports/Hobbies</a></li>
-    <li><a href="/ebooks/bookshelf/679">How To ...</a></li>
-    <li><a href="/ebooks/bookshelf/648">Travel Writing</a></li>
-    <li><a href="/ebooks/bookshelf/683">Nature/Gardening/Animals</a></li>
-    <li><a href="/ebooks/bookshelf/703">Sexuality &amp; Erotica</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="religion-philosophy" tabindex="-1">Religion &amp; Philosophy</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/692">Religion/Spirituality</a></li>
+      <li><a href="/ebooks/bookshelf/691">Philosophy &amp; Ethics</a></li>
+    </ul>
+  </div>
 
-  <h2>Health &amp; Medicine</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/681">Health &amp; Medicine</a></li>
-    <li><a href="/ebooks/bookshelf/682">Drugs/Alcohol/Pharmacology</a></li>
-    <li><a href="/ebooks/bookshelf/684">Nutrition</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="lifestyle-hobbies" tabindex="-1">Lifestyle &amp; Hobbies</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/678">Cooking &amp; Drinking</a></li>
+      <li><a href="/ebooks/bookshelf/680">Sports/Hobbies</a></li>
+      <li><a href="/ebooks/bookshelf/679">How To ...</a></li>
+      <li><a href="/ebooks/bookshelf/648">Travel Writing</a></li>
+      <li><a href="/ebooks/bookshelf/683">Nature/Gardening/Animals</a></li>
+      <li><a href="/ebooks/bookshelf/703">Sexuality &amp; Erotica</a></li>
+    </ul>
+  </div>
 
-  <h2>Education &amp; Reference</h2>
-  <ul>
-    <li><a href="/ebooks/bookshelf/697">Encyclopedias/Dictionaries/Reference</a></li>
-    <li><a href="/ebooks/bookshelf/704">Teaching &amp; Education</a></li>
-    <li><a href="/ebooks/bookshelf/702">Reports &amp; Conference Proceedings</a></li>
-    <li><a href="/ebooks/bookshelf/699">Journals</a></li>
-  </ul>
+  <div class="book-list">
+    <h2 id="health-medicine" tabindex="-1">Health &amp; Medicine</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/681">Health &amp; Medicine</a></li>
+      <li><a href="/ebooks/bookshelf/682">Drugs/Alcohol/Pharmacology</a></li>
+      <li><a href="/ebooks/bookshelf/684">Nutrition</a></li>
+    </ul>
+  </div>
+
+  <div class="book-list">
+    <h2 id="education-reference" tabindex="-1">Education &amp; Reference</h2>
+    <ul>
+      <li><a href="/ebooks/bookshelf/697">Encyclopedias/Dictionaries/Reference</a></li>
+      <li><a href="/ebooks/bookshelf/704">Teaching &amp; Education</a></li>
+      <li><a href="/ebooks/bookshelf/702">Reports &amp; Conference Proceedings</a></li>
+      <li><a href="/ebooks/bookshelf/699">Journals</a></li>
+    </ul>
+  </div>
 </div>

--- a/site/index.md
+++ b/site/index.md
@@ -3,80 +3,133 @@ layout: default
 title: Free eBooks | Project Gutenberg
 permalink: /
 ---
+<link rel="stylesheet" href="/gutenberg/homepage.css">
 
-Project Gutenberg is a library of over 75,000 free eBooks
-====================================================
+<h1 id="slogan"> Project Gutenberg is a library of over 75,000 free eBooks </h1>
 
-Choose among free epub and Kindle eBooks, download them or read them online. You will find the world's great literature here, with focus on older works for which U.S. copyright has expired. Thousands of volunteers digitized and diligently proofread the eBooks, for you to enjoy. 
+<p id="sub-slogan"> Choose among free epub and Kindle eBooks, download them or read them online. You will find the world's great literature here, with focus on older works for which U.S. copyright has expired. Thousands of volunteers digitized and diligently proofread the eBooks, for you to enjoy. </p>
 
-{% include latest_books_template.html %}
+<!-- Latest Books -->
+<div class="library" style="overflow-x: auto; position: relative;">
+  <div class="box_shadow" style="min-width: 1260px;">
+    <p><i style="font-size: 1.35rem;">Newest Releases</i> <a href="/browse/recent/last1">find more</a></p>
+    <div class="lib latest no-select">
+    {% include latest_covers.html %}
+   </div>
+ </div>
+</div>
 
+<div class="info-box-container">
+  <div class="info-box">
+    <h3>Find Free eBooks</h3>
+    <ul>
+      <li><a href="/browse/scores/top">Frequently downloaded</a>: Top 100, or ranked <a href="/ebooks/search/?sort_order=downloads">by popularity</a>.</li>
+      <li><a href="/ebooks/categories">Main Categories</a>. The ones you'd find in any large bookstore.</li>
+      <li><a href="/ebooks/bookshelf/">Reading Lists</a>. Hand-curated by volunteers.</li>
+      <li><a href="/ebooks/">Search Options</a>. By author, title, subject, language, type, popularity, and more.</li>
+      <li>Visit <a href="http://self.gutenberg.org">self.gutenberg.org</a> for free eBooks by contemporary authors.</li>
+    </ul>
+  </div>
 
-## Find Free eBooks
+  <div class="info-box">
+    <h3>Project Gutenberg</h3>
+    <ul>
+      <li>✓ <strong>100% Free</strong> - No fees, no registration, completely free</li>
+      <li>✓ <strong>No Apps Required</strong> - only regular Web browsers or eBook readers needed</li>
+      <li>✓ <strong>50+ Years</strong> - Pioneering free eBooks since 1971</li>
+      <li>✓ <strong>Volunteer-based</strong> - hundreds of volunteers have contributed over the years</li>
+      <li class="small-text">Consider a small donation to help us digitize more books: <a href="/donate"> donate </a></li>
+    </ul>
+  </div>
+</div>
 
-- [Search Options](/ebooks/). By author, title, subject, language, type, popularity, and more.
-- [Main Categories](/ebooks/categories). The ones you'd find in any large bookstore.
-- [Reading Lists](/ebooks/bookshelf/). Hand-curated by volunteers.
-- [Frequently downloaded](/browse/scores/top): Top 100, or ranked [by popularity](/ebooks/search/?sort_order=downloads).
-- Visit [self.gutenberg.org](http://self.gutenberg.org) for free eBooks by contemporary authors.
+<!-- Random Selection -->
+<div class="library" style="overflow-x: auto; position: relative;">
+  <div class="box_shadow" style="min-width: 1260px;">
+    <p><i style="font-size: 1.35rem;">Random Selection</i> <a href="/ebooks/search/?sort_order=random">find more</a></p>
+    <div class="lib latest no-select">
+    {% include latest_covers.html %}
+   </div>
+ </div>
+</div>
 
+<div class="category-grid">
+  <a href="/ebooks/categories.html#history" data-emoji="🏛️">History</a>
+  <a href="/ebooks/categories.html#literature" data-emoji="📜">Literature</a>
+  <a href="/ebooks/categories.html#science-technology" data-emoji="🔭">Science & Technology</a>
+  <a href="/ebooks/categories.html#social-sciences-society" data-emoji="🧑‍🤝‍🧑">Social Sciences & Society</a>
+  <a href="/ebooks/categories.html#arts-culture" data-emoji="🎨">Arts & Culture</a>
+  <a href="/ebooks/categories.html#religion-philosophy" data-emoji="☯️">Religion & Philosophy</a>
+  <a href="/ebooks/categories.html#lifestyle-hobbies" data-emoji="🎯">Lifestyle & Hobbies</a>
+  <a href="/ebooks/categories.html#health-medicine" data-emoji="🌿">Health & Medicine</a>
+  <a href="/ebooks/categories.html#education-reference" data-emoji="🎓">Education & Reference</a>
+</div>
 
-**No fee or registration!** Everything from Project Gutenberg is gratis, libre, and completely without cost to readers. If you find Project Gutenberg useful, please consider a small donation to help Project Gutenberg digitize more books, maintain its online presence, and improve Project Gutenberg programs and offerings. Other ways to help include digitizing, proofreading and formatting, or reporting errors.
-
-**No special apps needed!** Project Gutenberg eBooks require no special apps to read, just the regular Web browsers or eBook readers that are included with computers and mobile devices. There have been reports of sites that charge fees for custom apps, or for the same eBooks that are freely available from Project Gutenberg. Some of the apps might have worthwhile features, but none are required to enjoy Project Gutenberg eBooks. 
-
-**50 years of eBooks 1971-2021.** In 2021, Project Gutenberg celebrated the [first eBook](/ebooks/1) for reading enjoyment and unlimited free redistribution. This eBook was created on July 4, 1971 by Project Gutenberg's founder, Michael S. Hart. [Read more about this lasting innovation](/about/background/50years.html). Project Gutenberg is grateful to all volunteers who helped to reach this milestone anniversary. Project Gutenberg offers a vibrant and growing collection of the world's great literature. Read, enjoy, and share! 
-
-**New donation option** with Give Freely. <a href="/donate/index.html#givefreely">More information...</a>.
-
-
-
-## Audio books
-
-Audio books are a great way to enjoy and share literature. Project Gutenberg no longer adds new audio books to the collection, and suggests these audio book resources. These audio books are all freely available and in the public domain in the US. They may be easily played back on computers, tablets, mobile phones, and other devices. They may be shared non-commercially, without limitation except in countries where the printed source is still copyrighted. All of the sources listed below are digitizations of texts from Project Gutenberg.
-
-- Project Gutenberg's [human-read audio books](/browse/categories/1). 662 titles read by people, sometimes with sound effects or other enhancements. These are from a few different contributors.
-- Project Gutenberg's [computer-generated audio books](/browse/categories/2). 386 titles from 2003, using text-to-speech automation. These are listenable but relatively low quality compared to today's technology.
-- Human-read audio books from [LibriVox](https://librivox.org). LibriVox is a volunteer community that produces high-quality performances that are done by many different volunteers. Follow the link to find audio books, and also to help create new audio books.
-- [The Project Gutenberg Open Audiobook Collection](https://aka.ms/audiobooks). Almost 5,000 titles from 2023, via a Project Gutenberg collaboration with Microsoft and MIT. These use neural text-to-speech technology for more natural-sounding computer-generated audio books. These audio books are also available on major music/podcast platforms as well as [The Internet Archive](https://archive.org/details/@project_gutenberg_and_microsoft?tab=uploads). Project Gutenberg and partners were recognized by TIME for this work in their [Best Inventions of 2023](https://time.com/collection/best-inventions-2023/6324762/project-gutenberg-open-audiobook-collection/).
-
-## Get Help
-  <div class="box_shadow">
+<div class="info-box-container">
+  <div class="info-box">
+    <h3> Get Help </h3>
     <ul>
       <li><a href="/help/faq.html">Frequently Asked Questions</a> about Project Gutenberg.</li>
       <li><a href="/help/">Help, How-To and FAQs</a>: In depth information about many topics.</li>
       <li><a href="/help/mobile.html">Tablets, phones and eReaders How-To</a>: Using tablets, Kindle, Nook, cell phone, and other mobile devices and readers.</li>
+      <h3> How to Help </h3> 
+      <li><a href="https://www.pgdp.net">Distributed Proofreaders</a> welcomes new volunteers. This is the main source of new Project Gutenberg eBooks. Getting started is easy, and just a page a day will help! </li>
+      <li><a href="/help/errata.html">Fix and improve</a> Project Gutenberg by reporting errors, bugs, typos, and suggesting changes.</li>
+      <li>Record audiobooks with our friends at <a href="https://librivox.org">LibriVox</a>.</li>
     </ul>
   </div>
 
-## How to Help
-
-- [Distributed Proofreaders](https://www.pgdp.net) welcomes new volunteers. This is the main source of new Project Gutenberg eBooks. Getting started is easy, and just a page a day will help!
-- [Fix and improve](/help/errata.html) Project Gutenberg by reporting errors, bugs, typos, and suggesting changes.
-- Record audiobooks with our friends at [LibriVox](https://librivox.org).
-
-
-## Special Areas
-
-- [About Project Gutenberg](/about/).
-- [Donating to Project Gutenberg](/donate/).
-- [Feeds](/ebooks/feeds.html) of new eBooks.
-- [Linking to Project Gutenberg](/policy/linking.html) and [roboting or crawling](/policy/robot_access.html) the site.
-- [Partners and affiliates](/about/partners_affiliates.html).
-- [Permissions, copyright, licensing, and trademark information](/policy/permission.html).
-- What does [free eBook](/about/background/free_ebook.html) (No Cost or Freedom?) mean?
-
-## Terms of Use
-
-<div class="box_shadow">
-<p>Project Gutenberg eBooks may be freely used in the United States because most are not protected by U.S. copyright law. They may not be free of copyright in other countries. Readers outside of the United States must check the copyright terms of their countries before accessing, downloading or redistributing eBooks. We also have a number of copyrighted titles, for which the copyright holder has given permission for unlimited non-commercial worldwide use.</p>
-
-<p>The Project Gutenberg website is for human users only. Use of automated tools to access the website may trigger a block of your access. This site utilizes cookies, captchas and related technologies to help assure the site is maximally available for human users. See full terms of use <a href="/policy/terms_of_use.html">here</a>.</p>
+  <div class="info-box">
+    <h3> Special Areas </h3>
+    <ul>
+      <li><a href="/about/">About Project Gutenberg</a>.</li>
+      <li><a href="/donate/">Donating to Project Gutenberg</a>.</li>
+      <li><a href="/ebooks/feeds.html">Feeds</a> of new eBooks.</li>
+      <li><a href="/policy/linking.html">Linking to Project Gutenberg</a> and <a href="/policy/robot_access.html">roboting or crawling</a> the site.</li>
+      <li><a href="/about/partners_affiliates.html">Partners and affiliates</a>.</li>
+      <li><a href="/policy/permission.html">Permissions, copyright, licensing, and trademark information</a>.</li>
+      <li>What does <a href="/about/background/free_ebook.html">free eBook</a> (No Cost or Freedom?) mean?</li>
+    </ul>
+  </div>
 </div>
 
-## Social Media
-{% include social_media_icons.html %}
-<!-- ## Contact Info
-
-- [Contact Information](/about/contact_information.html): How to get in touch.
-- [Mailing lists](https://lists.pglaf.org/): Subscribe to the monthly newsletter. -->
+<div class="info-box-container">
+  <div class="info-box">
+    <h3>Audio Books</h3>
+    <p> Audio books are a great way to enjoy literature. We recommend the following sources. All of them are digitizations of Project Gutenberg texts. They are freely available and in the public domain in the US. </p>
+    <ul>
+      <li> - <a href="/browse/categories/1">Project Gutenberg’s 662 titles read by people</a> </li>
+      <li> - <a href="https://librivox.org">Human-read audio books from LibriVox</a>. LibriVox is a volunteer community that produces high-quality performances. </li>
+      <li> - <a href="/browse/categories/2">The Project Gutenberg Open Audiobook Collection</a>. Almost 5,000 computer-generated titles from 2023 via a Project Gutenberg collaboration with Microsoft and MIT. </li>
+      <li> - <a href="/browse/categories/2">Project Gutenberg’s audio books from 2003</a>. They are computer-generated and listenable but relatively low quality compared to today’s technology. </li>
+    </ul>
+  </div>
+ 
+  <div class="info-box">
+    <h3>Our Social Media</h3>
+    <ul class="icon-list">
+      <br>
+      <li><a href="https://www.facebook.com/project.gutenberg">
+        <img src="/gutenberg/f_icon.png" alt="Facebook icon" >
+      </a></li>
+      <li><a href="https://mastodon.social/@gutenberg_org" rel="me">
+        <img src="/gutenberg/m_icon.png" alt="Mastodon icon" >
+      </a></li>
+      <li><a href="https://bsky.app/profile/gutenberg.org" rel="me">
+        <img src="/gutenberg/b_icon.png" alt="Bluesky icon" >
+      </a></li>
+      <br>
+      <h3>News Feeds of new eBooks</h3>
+      <br>
+      <li><a href="https://www.facebook.com/gutenberg.new">
+        <img src="/gutenberg/f_news_icon.png" alt="Facebook news feed icon" >
+      </a></li>
+      <li><a href="https://mastodon.social/@gutenberg_new" rel="me">
+        <img src="/gutenberg/m_news_icon.png" alt="Mastodon icon" >
+      </a></li>
+      <li><a href="https://bsky.app/profile/new.gutenberg.org" rel="me">
+        <img src="/gutenberg/b_news_icon.png" alt="Bluesky icon" >
+      </a></li>
+    </ul>
+  </div>
+</div>

--- a/site/index.md
+++ b/site/index.md
@@ -48,7 +48,7 @@ permalink: /
   <div class="box_shadow" style="min-width: 1260px;">
     <p><i style="font-size: 1.35rem;">Random Selection</i> <a href="/ebooks/search/?sort_order=random">find more</a></p>
     <div class="lib latest no-select">
-    {% include latest_covers.html %}
+    {% include random_covers.html %}
    </div>
  </div>
 </div>

--- a/site/index.md
+++ b/site/index.md
@@ -48,7 +48,7 @@ permalink: /
   <div class="box_shadow" style="min-width: 1260px;">
     <p><i style="font-size: 1.35rem;">Random Selection</i> <a href="/ebooks/search/?sort_order=random">find more</a></p>
     <div class="lib latest no-select">
-    {% include random_covers.html %}
+    {% include latest_covers.html %}
    </div>
  </div>
 </div>


### PR DESCRIPTION
UX Upgrade of homepage. The goal was to simply and streamline the current homepage and generally make it more user friendly  i.e. make it more conducive to leading first-time or infrequent users into the experience of actively using Gutenberg. 

As usual the design has been done with tablets and mobile actively in mind.

Many small changes are part of it. The important information is visual, so I'll post screenshots in scrolling order right below.

In terms of content all of the principle elements that are currently on the homepage are still there. Moreover we've added styled buttons that lead to the important "Main Category" sections (we stole that design choice from Amazon. presumably they know something about making people find books).

We've also added another "blue box", analogous to the current "Newest Releases" box, which is supposed to show a "Random Selection". For now we're just including "latest_covers.html" as a placeholder, since the functionality of a random selection still needs to be implemented. I've corresponded with @eshellman about this and it should be doable. It would make the homepage noticeably more interesting I believe/hope.

The changes in categories.md are just because it solves the same problem for the "Main Categories" page  that https://github.com/gutenbergtools/gutenbergsite/pull/152 solved for the "Reading Lists" page. Thought I might as well include that.

As usual, I don't claim that this is perfect. But I do believe it to be a clear step up from the status quo. Screenshots below.
 
