### PR TITLE
Fixes Homepage Update

### DIFF
--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -226,18 +226,25 @@ ul {
   margin-left: -1em;
 }
 
+.bookshelves h2:focus { outline: none; }
+
 /* highlights the relevant header if a user arrives via a "main categories" link on the homepage */
-.bookshelves h2:target,
-.bookshelves h2:focus {
-  background: #fffbd2;
-  border: 1px solid #a01f13;
-  padding: 0.25em 0.5em;
-  animation: flash 1.5s ease-in-out 3;
+@media only screen and (min-width: 751px) {
+  .bookshelves h2:target,
+  .bookshelves h2:focus {
+    background: #C7DDE3;
+    padding: 0.7em 0.5em;
+    animation: flash 1.5s ease-in-out 3;
+    font-size: 1.5em;
+    width: 80%;
+    display: inline-block;
+    box-sizing: border-box;
+  }
 }
 
 @keyframes flash {
-  0%, 100% { background: #fffbd2; }
-  50%      { background: #ffe17d; }
+  0%, 100% { background: #C7DDE3; }
+  50%      { background:#F0F0F0}
 }
 
 .bookshelves h2 {

--- a/site/index.md
+++ b/site/index.md
@@ -12,7 +12,7 @@ permalink: /
 <!-- Latest Books -->
 <div class="library">
   <div class="box_shadow">
-    <p><label for="more_recent">Newest Releases</label> <a href="/browse/recent/last1" id="more_recent" title="find more recent releases">find more</a></p>
+    <p><label for="more_recent">Newest Releases</label> <a href="/ebooks/search/?sort_order=downloads" id="more_recent" title="find more recent releases">find more</a></p>
     <div class="lib latest no-select">
     {% include latest_covers.html %}
    </div>


### PR DESCRIPTION
- fixed href of "find more" Newest Releases link
- removed :target effect of "Main Category" headings on mobile
- updated styling of that :target effect on larger screens

I looked into the horizontal scrolling suggestion on Slack. Sadly it seems to be true what was suggested in the group that these are browser settings. There are tricks to get around it, but they all seem to involve Javascript.
I also don't think it's a huge problem. I suggest we call it good enough and push forward.