### PR TITLE
break page content title on word for long titles on mobile

### DIFF
--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -403,6 +403,7 @@ ul {
   line-height: 1em;
   color: #aa873b;
   margin-top: 3.5em;
+  word-break: break-word;
 }
 
 .page_content h2::before {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="537" height="755" alt="image" src="https://github.com/user-attachments/assets/f55bbe02-e18a-4af2-8ec7-ace2145ad8dd" /> | <img width="539" height="742" alt="image" src="https://github.com/user-attachments/assets/a091fb0a-027d-47e5-afae-18d9bbdae865" /> |

Fixes #168 