### PR TITLE
Update home screen book carousel styling

### DIFF
--- a/gutenberg/homepage.css
+++ b/gutenberg/homepage.css
@@ -157,9 +157,24 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ---------- Latest Releases & Random Selection ---------- */
 .lib.latest {
+  overflow-x: auto;
   display: flex;
   gap: 28px;
   padding: 0px 0px 50px 0px;
+}
+
+.lib.latest::-webkit-scrollbar {
+  height: 10px;
+}
+
+.lib.latest::-webkit-scrollbar-thumb {
+  background-color: #b8b8b8;
+  border-radius: 10px;
+}
+
+.lib.latest::-webkit-scrollbar-track {
+  background-color: #f1f1f1;
+  border-radius: 10px;
 }
 
 .lib.latest .cover_image {
@@ -194,17 +209,18 @@ h1, h2, h3, h4, h5, h6 {
 /* ---------- 'Find more' link ---------- */
 .box_shadow p a {
   background-color: #C7DDE3;
-  padding: 0 12px;
+  padding: 5px 12px;
   border-radius: 3px;
 }
 
-.box_shadow p a:hover { filter: brightness(1.1); }
+.box_shadow p a:hover {
+  background-color: #7ebed0;
+}
 
 /* Responsive width for cover carousels */
 /* Library wrapper */
-.library {
-  overflow-x: auto;
-  position: relative;
+.library .box_shadow {
+  width: 100%;
 }
 
 /* Box Shadow heading label */

--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -423,7 +423,6 @@ ul {
 
 .page_content h3::before {
   display: block;
-  content: "";
   margin-top: -120px;
   height: 120px;
   visibility: hidden;
@@ -565,7 +564,6 @@ ul.icon-list li {
   height: 5em;
   text-decoration: none;
   text-align: center;
-  position: absolute;
   width: 100px;
   background-color: #d9eaef;
 }

--- a/site/index.md
+++ b/site/index.md
@@ -100,7 +100,7 @@ permalink: /
     <ul>
       <li> - <a href="/browse/categories/1">Project Gutenberg’s 662 titles read by people</a> </li>
       <li> - <a href="https://librivox.org">Human-read audio books from LibriVox</a>. LibriVox is a volunteer community that produces high-quality performances. </li>
-      <li> - <a href="/browse/categories/2">The Project Gutenberg Open Audiobook Collection</a>. Almost 5,000 computer-generated titles from 2023 via a Project Gutenberg collaboration with Microsoft and MIT. </li>
+      <li> - <a href="https://marhamilresearch4.blob.core.windows.net/gutenberg-public/Website/index.html">The Project Gutenberg Open Audiobook Collection</a>. Almost 5,000 computer-generated titles from 2023 via a Project Gutenberg collaboration with Microsoft and MIT. </li>
       <li> - <a href="/browse/categories/2">Project Gutenberg’s audio books from 2003</a>. They are computer-generated and listenable but relatively low quality compared to today’s technology. </li>
     </ul>
   </div>


### PR DESCRIPTION
## Description
Currently, the carousel scroll area is set to the entire container. This means when you scroll, the title disappears and when you are not scrolled, the border radius is uneven.

<details><summary>Problem Screenshots</summary>
<p>

<img width="1036" height="644" alt="image" src="https://github.com/user-attachments/assets/8be38d2f-d7bb-4d4f-a552-6b55068d6f11" />

<img width="994" height="462" alt="image" src="https://github.com/user-attachments/assets/1716eea7-ee64-493d-bb1e-b4bfe1a82a38" />

</p>
</details> 

To fix this, I have made the scroll area the inner card wrapper.

## Screenshots 📷 

### Scrolled to End
<img width="923" height="442" alt="image" src="https://github.com/user-attachments/assets/77d31cca-ece4-43b7-83d5-ed45ada78afa" />


### Desktop
<img width="2560" height="1301" alt="image" src="https://github.com/user-attachments/assets/71ccfa4f-4ac8-440e-8a58-1e6c11220303" />

### Laptop
<img width="1685" height="1122" alt="image" src="https://github.com/user-attachments/assets/a58652aa-72b4-4083-a0a2-dac2425c0c4d" />

### Tablet
<img width="956" height="1244" alt="image" src="https://github.com/user-attachments/assets/fbb69b93-ee79-4d4d-9e8f-b9ac92ca1c30" />

### Mobile
<img width="425" height="1299" alt="image" src="https://github.com/user-attachments/assets/59d68f73-29d6-4d5c-a569-a1ab89c838ac" />
