### PR TITLE
Update new_nav.css to restore spacing of DL/DT/DD tags

### DIFF
--- a/gutenberg/new_nav.css
+++ b/gutenberg/new_nav.css
@@ -4,6 +4,12 @@
   box-sizing: border-box;
 }
 
+/* The following 2 lines can be removed if the "mini reset"
+   above using the * selector is removed.
+*/
+dt {margin-bottom: .2em;}
+dd {margin-bottom: 1em; margin-left: 2em;}
+
 header {
   width: 100%;
   display: flex;


### PR DESCRIPTION
Restore spacing that was lost due to mini-reset styling. The impact is difficult to detect due 1) the * selector hits EVERYTHING on the whole site, 2) the DL/DT/DD tags are not searchable in the repo code due to the use of Markdown to generate the HTML. This is the minimum change that will restore the spacing for this one set of tags.